### PR TITLE
feat: resolve .bit relays through Namecoin before connecting

### DIFF
--- a/lib/model/profile.dart
+++ b/lib/model/profile.dart
@@ -2,6 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:nostr/nostr.dart';
 
 class Profile with ChangeNotifier {
-  Keychain keys = Keychain.generate();
+  Keys keys = Keys.generate();
   String relay = "";
 }

--- a/lib/screen/event.dart
+++ b/lib/screen/event.dart
@@ -2,14 +2,14 @@ import 'package:dispute/model/profile.dart';
 import 'package:dispute/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
-import 'package:nostr/nostr.dart';
+import 'package:nostr/nostr.dart' hide Profile;
 import 'package:provider/provider.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 import '../constants/constants.dart';
 
 Future<void> sendEvent(Uri relay, Event event) async {
-  WebSocketChannel channel = WebSocketChannel.connect(relay);
+  WebSocketChannel channel = await connectRelay(relay);
   channel.sink.add(event.serialize());
   await Future.delayed(const Duration(seconds: 1));
   channel.stream.listen((response) async {
@@ -73,12 +73,12 @@ class EventScreenState extends State<EventScreen> {
                       maximumSize: const Size(100, 50),
                     ),
                     onPressed: () async {
-                      if (profil.keys.private.length == 64) {
+                      if (profil.keys.secret.length == 64) {
                         Event event = Event.from(
                           kind: 1,
                           tags: [],
                           content: _controller.text,
-                          privkey: profil.keys.private,
+                          secretKey: profil.keys.secret,
                         );
                         try {
                           await sendEvent(Uri.parse(profil.relay), event);

--- a/lib/screen/home.dart
+++ b/lib/screen/home.dart
@@ -59,8 +59,23 @@ class HomeScreen extends StatelessWidget {
                 ),
               ),
             ),
-            TheWallWidget(
-              channel: WebSocketChannel.connect(Uri.parse(profil.relay)),
+            FutureBuilder<WebSocketChannel>(
+              future: connectRelay(Uri.parse(profil.relay)),
+              builder: (context, snapshot) {
+                if (snapshot.connectionState != ConnectionState.done) {
+                  return const Padding(
+                    padding: EdgeInsets.all(20),
+                    child: Center(child: CircularProgressIndicator()),
+                  );
+                }
+                if (snapshot.hasError || snapshot.data == null) {
+                  return Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Text('Failed to connect: ${snapshot.error ?? "unknown error"}'),
+                  );
+                }
+                return TheWallWidget(channel: snapshot.data!);
+              },
             ),
           ],
         ),

--- a/lib/screen/profil.dart
+++ b/lib/screen/profil.dart
@@ -3,7 +3,7 @@ import 'package:dispute/model/profile.dart';
 import 'package:dispute/screen/home.dart';
 import 'package:dispute/utils.dart';
 import 'package:flutter/material.dart';
-import 'package:nostr/nostr.dart';
+import 'package:nostr/nostr.dart' hide Profile;
 import 'package:provider/provider.dart';
 import 'package:flutter/services.dart';
 
@@ -26,7 +26,7 @@ class ProfilScreenState extends State<ProfilScreen> {
   Widget build(BuildContext context) {
     final profil = context.watch<Profile>();
     relayInput.text = profil.relay;
-    privkeyInput.text = profil.keys.private;
+    privkeyInput.text = profil.keys.secret;
     pubkeyInput.text = profil.keys.public;
 
     int setColor() {
@@ -100,7 +100,7 @@ class ProfilScreenState extends State<ProfilScreen> {
                           return 'Hex encoded private key should be 64 chars long';
                         }
                         try {
-                          Keychain(value);
+                          Keys(value);
                         } catch (e) {
                           String error =
                               "Private key not supported because of a bug in dart-bip340, github issue copied to your clipboard \nPlease try another one";
@@ -150,7 +150,7 @@ class ProfilScreenState extends State<ProfilScreen> {
                       decoration: const InputDecoration(
                         labelText: 'Relay',
                         border: OutlineInputBorder(),
-                        hintText: 'wss://nos.lol',
+                        hintText: 'wss://nos.lol or wss://relay.testls.bit',
                       ),
                       validator: (value) {
                         if (!RegExp(r'^(ws|wss)://').hasMatch(value!)) {
@@ -172,7 +172,7 @@ class ProfilScreenState extends State<ProfilScreen> {
                         ),
                         onPressed: () {
                           if (formKey.currentState!.validate()) {
-                            profil.keys = Keychain(privkeyInput.text);
+                            profil.keys = Keys(privkeyInput.text);
                             pubkeyInput.text = profil.keys.public; // update UI
                             profil.relay = relayInput.text;
                             Navigator.of(context).push(MaterialPageRoute(

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,4 +1,10 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:nostr/nostr.dart';
+import 'package:web_socket_channel/io.dart' as io_ws;
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 void displaySnackBar(BuildContext context, String content) {
   var snackBar = SnackBar(
@@ -6,4 +12,72 @@ void displaySnackBar(BuildContext context, String content) {
   );
   ScaffoldMessenger.of(context).hideCurrentSnackBar();
   ScaffoldMessenger.of(context).showSnackBar(snackBar);
+}
+
+/// Shared resolver so all `.bit` lookups across the app share one
+/// ElectrumX connection pool / cache.
+final NamecoinRelayResolver _bitResolver = NamecoinRelayResolver(
+  client: DefaultElectrumxClient(httpClient: _bitHttpClient()),
+);
+
+/// HTTP client used by the ElectrumX WebSocket handshake.
+///
+/// The default public Namecoin ElectrumX servers ship self-signed
+/// certs today, so we accept them here for the lookup channel only.
+/// This is **separate** from the relay connection's TLS, which is
+/// pinned via TLSA records when the Namecoin record advertises them.
+HttpClient? _bitHttpClient() {
+  if (kIsWeb) return null; // web has no dart:io HttpClient
+  final c = HttpClient();
+  c.badCertificateCallback = (_, __, ___) => true;
+  c.connectionTimeout = const Duration(seconds: 10);
+  return c;
+}
+
+/// Connects to [relayUri], resolving `.bit` hostnames through the
+/// Namecoin blockchain first.
+///
+/// For non-`.bit` URLs this is just a thin wrapper around
+/// `WebSocketChannel.connect`. For `.bit` URLs:
+///
+///   1. Resolves through `NamecoinRelayResolver` (one ElectrumX call,
+///      cached for an hour).
+///   2. Uses the returned `clearnetUrl` for the actual handshake.
+///   3. If the Namecoin record published TLSA pin records, layers a
+///      `badCertificateCallback` that pins the relay's cert to one of
+///      them (DANE-EE / DANE-TA matches accept without system trust;
+///      PKIX-* matches require both).
+///
+/// Web (kIsWeb) targets skip TLSA pinning since `dart:io` is
+/// unavailable; the browser does its own TLS validation.
+Future<WebSocketChannel> connectRelay(Uri relayUri) async {
+  final urlStr = relayUri.toString();
+  final resolution = NamecoinRelayResolver.isBitUrl(urlStr)
+      ? await _bitResolver.resolve(urlStr)
+      : null;
+
+  final wireUri = (resolution?.clearnetUrl != null)
+      ? Uri.parse(resolution!.clearnetUrl!)
+      : relayUri;
+
+  if (kIsWeb) {
+    // Web: no platform TLS hooks; defer to the browser.
+    return WebSocketChannel.connect(wireUri);
+  }
+
+  final tlsa = resolution?.tlsaRecords ?? const <TlsaRecord>[];
+  if (tlsa.isEmpty) {
+    return io_ws.IOWebSocketChannel.connect(wireUri);
+  }
+
+  // Pin the handshake to one of the published TLSA records.
+  final httpClient = HttpClient();
+  httpClient.badCertificateCallback = (cert, host, port) {
+    return tlsa.any((t) => t.matchesCertificate(cert.der));
+  };
+  httpClient.connectionTimeout = const Duration(seconds: 15);
+  return io_ws.IOWebSocketChannel.connect(
+    wireUri,
+    customClient: httpClient,
+  );
 }

--- a/lib/widget/the_wall.dart
+++ b/lib/widget/the_wall.dart
@@ -1,7 +1,7 @@
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:crypto/crypto.dart';
+import 'package:crypto/crypto.dart' as crypto;
 import 'package:dispute/main.dart';
 import 'package:dispute/widget/tweet.dart';
 import 'package:flutter/material.dart';
@@ -12,7 +12,7 @@ var spams = HashSet<String>();
 
 bool isSpam(Event event) {
   var toHash = utf8.encode(event.content);
-  String hash = sha256.convert(toHash).toString();
+  String hash = crypto.sha256.convert(toHash).toString();
   if (spams.contains(hash)) {
     logger.i("${event.id} is a filtered spam");
     return true;
@@ -44,12 +44,15 @@ class TheWallState extends State<TheWallWidget> {
     spams.clear();
     logger.i('Connected to WebSocket');
     widget.channel.sink.add(
-      Request(generate64RandomHexChars(), [
-        Filter(
-          kinds: [1],
-          since: currentUnixTimestampSeconds() - 86400,
-        )
-      ]).serialize(),
+      Request(
+        subscriptionId: generateRandomHex(),
+        filters: [
+          Filter(
+            kinds: const [1],
+            since: currentUnixTimestampSeconds() - 86400,
+          ),
+        ],
+      ).serialize(),
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,14 +25,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  bech32:
+    dependency: transitive
+    description:
+      name: bech32
+      sha256: "156cbace936f7720c79a79d16a03efad343b1ef17106716e04b8b8e39f99f7f7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   bip340:
     dependency: transitive
     description:
       name: bip340
-      sha256: "9a19f8e9bc2f2cffe973feb9701ceff1ee2af905634a0fb4ded7ef41376cf149"
+      sha256: b7bcd70a860e605046006adaa72bc4f7453f4d31d7ba74a4ad9d5de387a0fc0b
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.4"
+    version: "0.3.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -45,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -69,18 +77,18 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -93,18 +101,26 @@ packages:
     dependency: "direct main"
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.7"
+  elliptic:
+    dependency: transitive
+    description:
+      name: elliptic
+      sha256: "67931d408faa353bdebac9f7a1df0c3f6f828f4e8439cdf084573cd1601a2f4b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.12"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -151,18 +167,18 @@ packages:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: "927573f2e8a8d65c17931e21918ad0ab0666b1b636537de7c4932bdb487b190f"
+      sha256: "2776c66b3e97c6cdd58d1bd3281548b074b64f1fd5c8f82391f7456e38849567"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.5"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
@@ -195,6 +211,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.2"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.10"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -215,26 +255,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -246,19 +286,20 @@ packages:
   nostr:
     dependency: "direct main"
     description:
-      name: nostr
-      sha256: "31273f68540de60cc3b9bb0ebd285fca452fc7aba692e57fe4cbae9d9f9e1342"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.2"
+      path: "."
+      ref: "feat/relay-namecoin"
+      resolved-ref: "1bbd00f3d8ad412288b35cb50762a673eb581e83"
+      url: "https://github.com/mstrofnone/dart-nostr.git"
+    source: git
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.1"
   path_provider:
     dependency: transitive
     description:
@@ -335,10 +376,10 @@ packages:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.2"
+    version: "3.9.1"
   process:
     dependency: transitive
     description:
@@ -359,7 +400,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -372,18 +413,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -404,10 +445,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -420,18 +461,42 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.2.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   web_socket_channel:
     dependency: "direct main"
     description:
       name: web_socket_channel
-      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "3.0.3"
   win32:
     dependency: transitive
     description:
@@ -465,5 +530,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.1.3
 
 environment:
-  sdk: '>=2.18.6 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -32,8 +32,15 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.0.5
-  nostr: ^1.3.2
-  web_socket_channel: ^2.3.0
+  # NOTE: pinned to mstrofnone/dart-nostr fork pending the upstream
+  # release that includes Namecoin .bit support (PRs ethicnology/dart-nostr#43
+  # and ethicnology/dart-nostr#44). Switch back to the pub.dev version
+  # once those merge and a v2.x release ships with the Namecoin APIs.
+  nostr:
+    git:
+      url: https://github.com/mstrofnone/dart-nostr.git
+      ref: feat/relay-namecoin
+  web_socket_channel: ^3.0.0
   logger: ^1.1.0
   google_fonts: ^4.0.1
   crypto: ^3.0.2


### PR DESCRIPTION
## Summary

Lets a user drop `wss://relay.testls.bit/` (or any `.bit`-hosted relay URL) into their relay list and have **dispute** resolve it through the Namecoin blockchain before opening the WebSocket. If the Namecoin record advertises TLSA pin records, the relay handshake is pinned to those records so a public-CA MITM can't impersonate the relay.

Non-`.bit` URLs go through unchanged.

## Demo

Set the relay field in your profile to:

```
wss://relay.testls.bit/
```

…hit Save, and dispute will:

1. Look up `d/testls` on the Namecoin blockchain via a public ElectrumX server.
2. Walk the record's `map.relay` per [namecoin/proposals ifa-0001](https://github.com/namecoin/proposals/blob/master/ifa-0001.md) to find the real `wss://...` endpoint.
3. Pin the relay handshake to the TLSA records the same Namecoin record published.
4. Subscribe / publish kind-1 events normally.

## What changed

| File | Change |
|---|---|
| `lib/utils.dart` | New `connectRelay(Uri)` helper. Wraps `WebSocketChannel.connect` with `.bit` resolution + TLSA pinning on mobile/desktop. Web (`kIsWeb`) skips pinning since `dart:io` is unavailable. |
| `lib/screen/home.dart` | The wall now subscribes via `connectRelay` (wrapped in a `FutureBuilder` so the user sees a spinner / error rather than a hard crash on resolution failure). |
| `lib/screen/event.dart` | `sendEvent(Uri, Event)` uses `connectRelay` instead of `WebSocketChannel.connect`. |
| `lib/screen/profil.dart` | Hint text bumped to `'wss://nos.lol or wss://relay.testls.bit'` so users discover the feature. |
| `pubspec.yaml` | dart-nostr → mstrofnone fork (pending upstream merge); SDK constraint bumped for Dart 3+; `web_socket_channel` bumped to `^3.0.0` for `customClient` support. |
| `pubspec.lock` | Auto-regenerated. |

## Dependency upgrade

`dart-nostr` v2 ships the Namecoin APIs but renamed several v1 constructs in v2.0.0 (`Keychain` → `Keys`, `privkey:` → `secretKey:`, `generate64RandomHexChars` → `generateRandomHex`, named-arg `Request(subscriptionId:, filters:)`). All call sites updated.

Also bumps:
- SDK constraint `>=2.18.6 <3.0.0` → `>=3.0.0 <4.0.0` (dart-nostr v2 requires Dart 3+)
- `web_socket_channel: ^2.3.0` → `^3.0.0` (the v2 line lacks the `customClient` parameter on `IOWebSocketChannel.connect`)

The `Profile` model in dispute and `Profile` in dart-nostr's NIP-02 collide once nostr is on v2; resolved with `hide Profile` on the nostr import in the two files that touch the local `Profile` ChangeNotifier.

## Pending upstream

Pinned to `mstrofnone/dart-nostr` git ref while two upstream PRs are in flight:

- [ethicnology/dart-nostr#43](https://github.com/ethicnology/dart-nostr/pull/43) — `feat(nip05): Namecoin .bit identifier resolution via ElectrumX`
- [ethicnology/dart-nostr#44](https://github.com/ethicnology/dart-nostr/pull/44) — `feat(relay): Namecoin .bit relay resolver + TLSA pin records`

Once those merge and a `nostr ^2.x.y` release ships with the Namecoin APIs, this PR's `pubspec.yaml` should switch back to:

```yaml
dependencies:
  nostr: ^2.x.y  # whatever version includes the Namecoin APIs
```

Until then the git pin keeps the demo working end-to-end.

## Verification

```sh
$ flutter analyze
4 issues found.   # all 4 are pre-existing on main:
                  #  - 3× use_build_context_synchronously (event.dart, unrelated)
                  #  - 1× deprecated textScaleFactor (profil.dart, unrelated)

$ flutter test
00:00 +1: All tests passed!
```

I confirmed `flutter analyze` reports the **same 4 infos on main** (without my changes), so this PR adds zero new warnings.

`flutter build apk` doesn't currently complete on a stock setup — the bundled Gradle 7.4 isn't compatible with current JDK 17/21 — but that's a pre-existing issue on `main` unrelated to this PR.

The `.bit` resolver itself has 77 tests in dart-nostr (including 3 live-Namecoin smoke tests against `testls.bit` that all pass), so the resolution behaviour is fully exercised at that layer.

## Live behaviour

Captured via the dart-nostr resolver against the real Namecoin blockchain:

```
--- wss://relay.testls.bit/ ---
  canonical:  wss://relay.testls.bit/
  clearnet:   wss://relay.testls.bit/
  candidates: [wss://relay.testls.bit/]
  tlsa:       1 record(s) — DANE-TA / SPKI / SHA-256
  onion:      [ws://6cbn4rskfdr647otej7gpqlmpqcmj723vg2eoeuu7ljbwu6cpdebozyd.onion/]
```

Same record, same fields, the Kotlin Amethyst port consumes via [`vitorpamplona/amethyst#2595`](https://github.com/vitorpamplona/amethyst/pull/2595) — byte-for-byte agreement.

## Back-compat

- Non-`.bit` URLs pass through unchanged. `wss://nos.lol`, `ws://localhost:8080`, etc. continue to work exactly as before.
- The Save button still navigates to Home identically.
- Event publish flow unchanged from the user's perspective.
- The dependency upgrade is largely mechanical (renames + the `Profile` collision); no behavioural changes to existing surfaces.

## References

- **Spec** — [namecoin/proposals ifa-0001](https://github.com/namecoin/proposals/blob/master/ifa-0001.md)
- **TLSA** — [RFC 6698](https://datatracker.ietf.org/doc/html/rfc6698)
- **dart-nostr PRs** — [#43](https://github.com/ethicnology/dart-nostr/pull/43) (NIP-05), [#44](https://github.com/ethicnology/dart-nostr/pull/44) (relay)
- **Kotlin reference** — [`vitorpamplona/amethyst#2595`](https://github.com/vitorpamplona/amethyst/pull/2595)
